### PR TITLE
turn off deprecation errors in opentelemetry-php while in alpha status

### DIFF
--- a/ratings/html/index.php
+++ b/ratings/html/index.php
@@ -7,6 +7,9 @@ require __DIR__.'/vendor/autoload.php';
 use Instana\RobotShop\Ratings\Kernel;
 use Symfony\Component\HttpFoundation\Request;
 
+# Turn off deprecation messages as per https://github.com/open-telemetry/opentelemetry-php/commit/99fba0d720785dfe9faba310e6e2e78fae9c075d
+OpenTelemetry\SDK\Common\Dev\Compatibility\Util::setErrorLevel(0)
+
 $env = getenv('APP_ENV') ?: 'dev';
 $kernel = new Kernel($env, true);
 $request = Request::createFromGlobals();


### PR DESCRIPTION
Turn off deprecation messages as per https://github.com/open-telemetry/opentelemetry-php/commit/99fba0d720785dfe9faba310e6e2e78fae9c075d

Resolves https://github.com/instana/otel-shop/issues/270

Verified locally that the component starts up and reports ready after the change

Signed-off-by: esara <endre.sara@turbonomic.com>