### PR TITLE
disable jvm.threads and logback micrometer shims to avoid duplicate metric messages

### DIFF
--- a/shipping/src/main/java/com/instana/robotshop/shipping/JpaConfig.java
+++ b/shipping/src/main/java/com/instana/robotshop/shipping/JpaConfig.java
@@ -19,7 +19,6 @@ public class JpaConfig {
 
         DataSourceBuilder bob = DataSourceBuilder.create();
 
-        bob.driverClassName("com.mysql.jdbc.Driver");
         bob.url(JDBC_URL);
         bob.username("shipping");
         bob.password("secret");

--- a/shipping/src/main/resources/application.properties
+++ b/shipping/src/main/resources/application.properties
@@ -4,3 +4,8 @@ management.endpoint.info.enabled=true
 management.endpoint.health.enabled=true
 management.endpoint.metrics.enabled=true
 management.endpoint.env.enabled=true
+
+# Temporarily disable micrometers to work around https://github.com/open-telemetry/opentelemetry-java/issues/4381
+# TODO: remove after upgrading to open-telemetry-java 1.14.1 or later
+management.metrics.enable.jvm=false
+management.metrics.enable.logback=false


### PR DESCRIPTION
after disabling the jvm.threads and logback micrometer shims, the shipping service starts up without errors

```
$ oc logs -f -n otel-shop otel-shop-shipping-797b7b97f5-kblqd  
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
[main] INFO io.opentelemetry.javaagent.tooling.VersionLogger - opentelemetry-javaagent - version: 1.14.0

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::                (v2.7.0)

2022-05-24 20:06:42.393  INFO 1 --- [           main] c.i.r.s.ShippingServiceApplication       : Starting ShippingServiceApplication v0.1.149 using Java 18.0.1.1 on otel-shop-shipping-797b7b97f5-kblqd with PID 1 (/opt/shipping/shipping.jar started by root in /opt/shipping)
2022-05-24 20:06:42.497  INFO 1 --- [           main] c.i.r.s.ShippingServiceApplication       : No active profile set, falling back to 1 default profile: "default"
2022-05-24 20:06:51.892  INFO 1 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data JPA repositories in DEFAULT mode.
2022-05-24 20:06:52.290  INFO 1 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 303 ms. Found 2 JPA repository interfaces.
2022-05-24 20:06:54.595  INFO 1 --- [           main] trationDelegate$BeanPostProcessorChecker : Bean 'shippingServiceApplication' of type [com.instana.robotshop.shipping.ShippingServiceApplication$$EnhancerBySpringCGLIB$$69bbeafc] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)
2022-05-24 20:06:57.484  INFO 1 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port(s): 8080 (http)
2022-05-24 20:06:57.880  INFO 1 --- [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
2022-05-24 20:06:57.881  INFO 1 --- [           main] org.apache.catalina.core.StandardEngine  : Starting Servlet engine: [Apache Tomcat/9.0.63]
2022-05-24 20:06:58.485  INFO 1 --- [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
2022-05-24 20:06:58.485  INFO 1 --- [           main] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 15305 ms
2022-05-24 20:07:00.284  INFO 1 --- [           main] c.instana.robotshop.shipping.JpaConfig   : jdbc url jdbc:mysql://otel-shop-mysql/cities?useSSL=false&autoReconnect=true&allowPublicKeyRetrieval=True
...
2022-05-24 20:11:06.412  INFO 1 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Starting...
2022-05-24 20:11:07.579  INFO 1 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Start completed.
2022-05-24 20:11:08.787  INFO 1 --- [           main] org.hibernate.dialect.Dialect            : HHH000400: Using dialect: org.hibernate.dialect.MySQL8Dialect
[instana-worker-com.instana.plugin.java] WARN io.opentelemetry.micrometer1shim.OpenTelemetryMeterRegistry - OpenTelemetry metrics bridge does not support reading measurements
2022-05-24 20:11:15.188  INFO 1 --- [           main] o.h.e.t.j.p.i.JtaPlatformInitiator       : HHH000490: Using JtaPlatform implementation: [org.hibernate.engine.transaction.jta.platform.internal.NoJtaPlatform]
2022-05-24 20:11:15.393  INFO 1 --- [           main] j.LocalContainerEntityManagerFactoryBean : Initialized JPA EntityManagerFactory for persistence unit 'default'
2022-05-24 20:11:20.794  WARN 1 --- [           main] JpaBaseConfiguration$JpaWebConfiguration : spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
2022-05-24 20:11:27.077  INFO 1 --- [           main] o.s.b.a.e.web.EndpointLinksResolver      : Exposing 1 endpoint(s) beneath base path '/actuator'
2022-05-24 20:11:27.583  INFO 1 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port(s): 8080 (http) with context path ''
2022-05-24 20:11:27.687  INFO 1 --- [           main] c.i.r.s.ShippingServiceApplication       : Started ShippingServiceApplication in 289.386 seconds (JVM running for 305.326)
2022-05-24 20:11:30.682  INFO 1 --- [nio-8080-exec-1] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring DispatcherServlet 'dispatcherServlet'
2022-05-24 20:11:30.683  INFO 1 --- [nio-8080-exec-1] o.s.web.servlet.DispatcherServlet        : Initializing Servlet 'dispatcherServlet'
2022-05-24 20:11:30.685  INFO 1 --- [nio-8080-exec-1] o.s.web.servlet.DispatcherServlet        : Completed initialization in 2 ms
```

resolves https://github.com/instana/otel-shop/issues/271

Signed-off-by: esara <endre.sara@turbonomic.com>