### PR TITLE
Adding service specific otel endpoint variables for cart and shipping

### DIFF
--- a/K8s/charts/otel-shop/templates/cart-deployment.yaml
+++ b/K8s/charts/otel-shop/templates/cart-deployment.yaml
@@ -27,7 +27,7 @@ spec:
               fieldRef:
                 fieldPath: status.hostIP
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: {{ .Values.opentelemetry.exporter.otlp.endpoint }}
+            value: {{ .Values.cart.opentelemetry.exporter.otlp.endpoint }}
           {{- if ne .Values.opentelemetry.exporter.otlp.headers "" }}
           - name: OTEL_EXPORTER_OTLP_HEADERS
             value: {{ .Values.opentelemetry.exporter.otlp.headers }}

--- a/K8s/charts/otel-shop/templates/shipping-deployment.yaml
+++ b/K8s/charts/otel-shop/templates/shipping-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
-          value: http://{{ .Values.opentelemetry.exporter.otlp.endpoint }}
+          value: {{ .Values.shipping.opentelemetry.exporter.otlp.endpoint }}
         {{- if ne .Values.opentelemetry.exporter.otlp.headers "" }}
         - name: OTEL_EXPORTER_OTLP_HEADERS
           value: {{ .Values.opentelemetry.exporter.otlp.headers }}

--- a/K8s/charts/otel-shop/values.yaml
+++ b/K8s/charts/otel-shop/values.yaml
@@ -1,4 +1,4 @@
-# Registry and rpository for Docker images
+# Registry and repository for Docker images
 # Default is docker/instanacedricziel/image:latest
 image:
   repo: instanacedricziel
@@ -12,6 +12,19 @@ image:
 payment:
   gateway: null
   #gateway: https://www.worldpay.com
+
+cart:
+  opentelemetry:
+    exporter:
+      otlp:
+        endpoint: "$(INSTANA_AGENT_HOST):4317"
+
+shipping:
+  opentelemetry:
+    exporter:
+      otlp:
+        # for "opentelemetry-javaagent" the url scheme is mandatory, either "http" or "https"
+        endpoint: "http://$(INSTANA_AGENT_HOST):4317"
 
 # EUM configuration
 # Provide your key and set the endpoint

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -139,7 +139,7 @@ services:
     networks:
       app-network:
     environment:
-      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:?No OpenTelemetry collector specified via OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${CART_OTEL_EXPORTER_OTLP_ENDPOINT:?No OpenTelemetry collector specified via CART_OTEL_EXPORTER_OTLP_ENDPOINT}
       OTEL_EXPORTER_OTLP_HEADERS: ${OTEL_EXPORTER_OTLP_HEADERS:?No OpenTelemetry headers specified via OTEL_EXPORTER_OTLP_HEADERS}
       OTEL_SERVICE_NAME: otel-shop-cart
     healthcheck:
@@ -297,7 +297,7 @@ services:
       CART_ENDPOINT: cart:8080
       DB_HOST: mysql
       REDIS_URL: redis://redis:6379
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://${OTEL_EXPORTER_OTLP_ENDPOINT:?No OpenTelemetry collector specified via OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${SHIPPING_OTEL_EXPORTER_OTLP_ENDPOINT:?No OpenTelemetry collector specified via SHIPPING_OTEL_EXPORTER_OTLP_ENDPOINT}
       OTEL_EXPORTER_OTLP_HEADERS: ${OTEL_EXPORTER_OTLP_HEADERS:?No OpenTelemetry headers specified via OTEL_EXPORTER_OTLP_HEADERS}
       OTEL_SERVICE_NAME: otel-shop-shipping
       OTEL_TRACES_SAMPLER: always_on

--- a/env.template
+++ b/env.template
@@ -11,9 +11,13 @@ INSTANA_OTLP_ENDPOINT=your-otlp-endpoint.here:4317
 
 # For use with otel-collector, set this to "otel-collector:4317"
 OTEL_EXPORTER_OTLP_ENDPOINT=collector:4317
-
 # In case you need to supply additional headers
-OTEL_EXPORTER_OTLP_HEADERS=x-instana-key=${agent_key},x-instana-time=0
+OTEL_EXPORTER_OTLP_HEADERS=x-instana-key=${agent_key},x-instana-time=0,x-instana-host=123456789
+
+# allows to defined alternative collector endpoints for "cart" and "shipping"
+CART_OTEL_EXPORTER_OTLP_ENDPOINT=collector:4317
+# for "opentelemetry-javaagent" the url scheme is mandatory, either "http" or "https"
+SHIPPING_OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4317
 
 # [bump]
 PROJECT_VERSION=0.1.172


### PR DESCRIPTION
Make it possible for some services (cart and shipping) to report to another otel endpoint. 