### PR TITLE
feat: added @opentelemetry/resource-detector-instana to cart service

### DIFF
--- a/cart/README.md
+++ b/cart/README.md
@@ -1,0 +1,5 @@
+## Opentelemetry Cart service
+
+```
+CART_SERVER_PORT=44553 OTEL_EXPORTER_OTLP_ENDPOINT=localhost:55680 OTEL_EXPORTER_OTLP_INSECURE=true REDIS_URL=redis://localhost:6379 node -r ./tracer.js server.js
+```

--- a/cart/package-lock.json
+++ b/cart/package-lock.json
@@ -13,6 +13,8 @@
         "@opentelemetry/auto-instrumentations-node": "^0.30.0",
         "@opentelemetry/exporter-metrics-otlp-grpc": "^0.29.2",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.29.2",
+        "@opentelemetry/resource-detector-instana": "^0.2.0",
+        "@opentelemetry/resources": "^1.4.0",
         "@opentelemetry/sdk-metrics-base": "^0.29.2",
         "@opentelemetry/sdk-node": "^0.29.2",
         "body-parser": "^1.20.0",
@@ -274,6 +276,21 @@
         "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/resources": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+      "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/semantic-conventions": "1.3.1"
+      },
+      "engines": {
+        "node": ">=8.12.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
     "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
@@ -326,6 +343,21 @@
         "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+      "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/semantic-conventions": "1.3.1"
+      },
+      "engines": {
+        "node": ">=8.12.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
@@ -359,6 +391,21 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
       "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
       "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.3.1"
+      },
+      "engines": {
+        "node": ">=8.12.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/resources": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+      "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.3.1",
         "@opentelemetry/semantic-conventions": "1.3.1"
       },
       "engines": {
@@ -996,6 +1043,21 @@
         "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+      "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/semantic-conventions": "1.3.1"
+      },
+      "engines": {
+        "node": ">=8.12.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
@@ -1102,9 +1164,9 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-aws": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.1.0.tgz",
-      "integrity": "sha512-YoGB47aSkZ3ULUZpqlt27SU31bqeUuvzgikk/O0U7w9yWppb7WmOwW9/yMQ9pavxgwFzNiNfjM5xYpDK7bL3Tg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.1.1.tgz",
+      "integrity": "sha512-HPD8WMUJSVph+ImJVlP5OfJHCOXmfd/nhkdDos/5uy8Y0usURsL4OQLYrNGiGpdtbPAz+MC0CfQoYv+GXoaO6w==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/resources": "^1.0.0",
@@ -1135,41 +1197,56 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/resources": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
-      "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
+    "node_modules/@opentelemetry/resource-detector-instana": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-instana/-/resource-detector-instana-0.2.0.tgz",
+      "integrity": "sha512-vdgyZIuTjT8JRqbh/AaP1OQ+/4nkQhMkXZaHj6tYUYfDVq7XIISmRj8dYO8ZUYRKaaM2XAIuNGBBWB07GFXE+g==",
       "dependencies": {
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/semantic-conventions": "1.3.1"
+        "@opentelemetry/resources": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=8.12.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.4.0.tgz",
+      "integrity": "sha512-Q3pI5+pCM+Ur7YwK9GbG89UBipwJbfmuzSPAXTw964ZHFzSrz+JAgrETC9rqsUOYdUlj/V7LbRMG5bo72xE0Xw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/semantic-conventions": "1.4.0"
+      },
+      "engines": {
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
     "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
-      "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.3.1"
+        "@opentelemetry/semantic-conventions": "1.4.0"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
     "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
-      "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+      "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ==",
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/sdk-metrics-base": {
@@ -1205,6 +1282,21 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
       "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
       "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.3.1"
+      },
+      "engines": {
+        "node": ">=8.12.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics-base/node_modules/@opentelemetry/resources": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+      "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.3.1",
         "@opentelemetry/semantic-conventions": "1.3.1"
       },
       "engines": {
@@ -1283,6 +1375,21 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/resources": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+      "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/semantic-conventions": "1.3.1"
+      },
+      "engines": {
+        "node": ">=8.12.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
     "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
@@ -1312,6 +1419,21 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
       "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
       "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.3.1"
+      },
+      "engines": {
+        "node": ">=8.12.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+      "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.3.1",
         "@opentelemetry/semantic-conventions": "1.3.1"
       },
       "engines": {
@@ -4279,6 +4401,15 @@
             "@opentelemetry/semantic-conventions": "1.3.1"
           }
         },
+        "@opentelemetry/resources": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+          "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
+          "requires": {
+            "@opentelemetry/core": "1.3.1",
+            "@opentelemetry/semantic-conventions": "1.3.1"
+          }
+        },
         "@opentelemetry/semantic-conventions": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
@@ -4315,6 +4446,15 @@
             "@opentelemetry/semantic-conventions": "1.3.1"
           }
         },
+        "@opentelemetry/resources": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+          "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
+          "requires": {
+            "@opentelemetry/core": "1.3.1",
+            "@opentelemetry/semantic-conventions": "1.3.1"
+          }
+        },
         "@opentelemetry/semantic-conventions": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
@@ -4341,6 +4481,15 @@
           "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
           "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
           "requires": {
+            "@opentelemetry/semantic-conventions": "1.3.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+          "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
+          "requires": {
+            "@opentelemetry/core": "1.3.1",
             "@opentelemetry/semantic-conventions": "1.3.1"
           }
         },
@@ -4752,6 +4901,15 @@
             "@opentelemetry/semantic-conventions": "1.3.1"
           }
         },
+        "@opentelemetry/resources": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+          "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
+          "requires": {
+            "@opentelemetry/core": "1.3.1",
+            "@opentelemetry/semantic-conventions": "1.3.1"
+          }
+        },
         "@opentelemetry/semantic-conventions": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
@@ -4820,9 +4978,9 @@
       }
     },
     "@opentelemetry/resource-detector-aws": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.1.0.tgz",
-      "integrity": "sha512-YoGB47aSkZ3ULUZpqlt27SU31bqeUuvzgikk/O0U7w9yWppb7WmOwW9/yMQ9pavxgwFzNiNfjM5xYpDK7bL3Tg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.1.1.tgz",
+      "integrity": "sha512-HPD8WMUJSVph+ImJVlP5OfJHCOXmfd/nhkdDos/5uy8Y0usURsL4OQLYrNGiGpdtbPAz+MC0CfQoYv+GXoaO6w==",
       "requires": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/resources": "^1.0.0",
@@ -4841,27 +4999,36 @@
         "semver": "7.3.5"
       }
     },
-    "@opentelemetry/resources": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
-      "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
+    "@opentelemetry/resource-detector-instana": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-instana/-/resource-detector-instana-0.2.0.tgz",
+      "integrity": "sha512-vdgyZIuTjT8JRqbh/AaP1OQ+/4nkQhMkXZaHj6tYUYfDVq7XIISmRj8dYO8ZUYRKaaM2XAIuNGBBWB07GFXE+g==",
       "requires": {
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/semantic-conventions": "1.3.1"
+        "@opentelemetry/resources": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
+      }
+    },
+    "@opentelemetry/resources": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.4.0.tgz",
+      "integrity": "sha512-Q3pI5+pCM+Ur7YwK9GbG89UBipwJbfmuzSPAXTw964ZHFzSrz+JAgrETC9rqsUOYdUlj/V7LbRMG5bo72xE0Xw==",
+      "requires": {
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/semantic-conventions": "1.4.0"
       },
       "dependencies": {
         "@opentelemetry/core": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
-          "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+          "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
           "requires": {
-            "@opentelemetry/semantic-conventions": "1.3.1"
+            "@opentelemetry/semantic-conventions": "1.4.0"
           }
         },
         "@opentelemetry/semantic-conventions": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
-          "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA=="
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+          "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ=="
         }
       }
     },
@@ -4889,6 +5056,15 @@
           "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
           "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
           "requires": {
+            "@opentelemetry/semantic-conventions": "1.3.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+          "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
+          "requires": {
+            "@opentelemetry/core": "1.3.1",
             "@opentelemetry/semantic-conventions": "1.3.1"
           }
         },
@@ -4942,6 +5118,15 @@
             "shimmer": "^1.2.1"
           }
         },
+        "@opentelemetry/resources": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+          "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
+          "requires": {
+            "@opentelemetry/core": "1.3.1",
+            "@opentelemetry/semantic-conventions": "1.3.1"
+          }
+        },
         "@opentelemetry/semantic-conventions": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
@@ -4964,6 +5149,15 @@
           "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
           "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
           "requires": {
+            "@opentelemetry/semantic-conventions": "1.3.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+          "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
+          "requires": {
+            "@opentelemetry/core": "1.3.1",
             "@opentelemetry/semantic-conventions": "1.3.1"
           }
         },

--- a/cart/package.json
+++ b/cart/package.json
@@ -13,6 +13,8 @@
     "@opentelemetry/auto-instrumentations-node": "^0.30.0",
     "@opentelemetry/exporter-metrics-otlp-grpc": "^0.29.2",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.29.2",
+    "@opentelemetry/resource-detector-instana": "^0.2.0",
+    "@opentelemetry/resources": "^1.4.0",
     "@opentelemetry/sdk-metrics-base": "^0.29.2",
     "@opentelemetry/sdk-node": "^0.29.2",
     "body-parser": "^1.20.0",

--- a/cart/server.js
+++ b/cart/server.js
@@ -17,6 +17,9 @@ const counter = new promClient.Counter({
     registers: [register]
 });
 
+if (process.env.CART_DEBUG) {
+  api.diag.setLogger(new api.DiagConsoleLogger(), api.DiagLogLevel.ALL);
+}
 
 var redisConnected = false;
 var catalogueHost = process.env.CATALOGUE_HOST || 'catalogue'

--- a/cart/tracer.js
+++ b/cart/tracer.js
@@ -1,24 +1,57 @@
 'use strict';
 
-const opentelemetry = require("@opentelemetry/sdk-node");
+const opentelemetry = require('@opentelemetry/sdk-node');
 const api = require('@opentelemetry/api');
-const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node');
-const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-grpc');
-const { OTLPMetricExporter } = require("@opentelemetry/exporter-metrics-otlp-grpc");
+const {
+  getNodeAutoInstrumentations,
+} = require('@opentelemetry/auto-instrumentations-node');
+const {
+  OTLPMetricExporter,
+} = require('@opentelemetry/exporter-metrics-otlp-grpc');
+const {
+  SemanticResourceAttributes,
+} = require('@opentelemetry/semantic-conventions');
 
-const traceOtlpExporter = new OTLPTraceExporter({
-  url: process.env.OTEL_EXPORTER_OTLP_ENDPOINT
-});
+const {
+  instanaAgentDetector,
+} = require('@opentelemetry/resource-detector-instana');
 
-const metricOtlpExporter = new OTLPMetricExporter({
-  url: process.env.OTEL_EXPORTER_OTLP_ENDPOINT
-});
+const {
+  Resource,
+  envDetector,
+  processDetector,
+} = require('@opentelemetry/resources');
+const {
+  OTLPTraceExporter,
+} = require('@opentelemetry/exporter-trace-otlp-grpc');
 
-const sdk = new opentelemetry.NodeSDK({
-  traceExporter: traceOtlpExporter,
-  metricExporter: metricOtlpExporter,
-  autoDetectResources: true,
-  instrumentations: [getNodeAutoInstrumentations()],
-});
+(async function () {
+  const serviceName = 'Cart Otel Service';
+  const globalResource = new Resource({
+    [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
+  });
 
-sdk.start()
+  const traceOtlpExporter = new OTLPTraceExporter({
+    url: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
+  });
+
+  const metricOtlpExporter = new OTLPMetricExporter({
+    url: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
+  });
+
+  const sdk = new opentelemetry.NodeSDK({
+    traceExporter: traceOtlpExporter,
+    metricExporter: metricOtlpExporter,
+    instrumentations: [getNodeAutoInstrumentations()],
+    autoDetectResources: false,
+    resource: globalResource,
+  });
+
+  // attributes are automatically merged!
+  await sdk.detectResources({
+    detectors: [envDetector, processDetector, instanaAgentDetector],
+  });
+
+  api.diag.debug(`Merged resource ${JSON.stringify(sdk['_resource'])}`);
+  await sdk.start();
+})();


### PR DESCRIPTION
This PR adds the newly added Instana Otel resource detector to the cart codebase.

The resource detection processor can be used to detect resource information from the host.

In Opentelemetry there is the concept of a resource, see [[Resource SDK](https://opentelemetry.io/docs/reference/specification/resource/sdk/)](https://opentelemetry.io/docs/reference/specification/resource/sdk/). There are process resources, environment resources and custom resources. All will be merged into one resource object, which is attached to every trace object.

The goal for Instana is to use this component as a detector for our Instana agent and attach the real PID and the agent uuid to the custom resource. This will correlate the Otel service spans with the Otel process.

- [x] update Instana resource detector with the NPM package when the PR on https://github.com/open-telemetry/opentelemetry-js-contrib/pulls got merged